### PR TITLE
Support of a custom handling of Long Poll server errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ bot.get(/Hi|Hello|Hey/i, message => {
     - [`stop`](#stop)
   - [Events](#events)
     - [update](#update)
+    - [poll-error](#poll-error)
     - [command-notfound](#command-notfound)
 - [The `Message` Object](#the-message-object)
 
@@ -173,6 +174,17 @@ bot.on('update', update => {
   if (update[7].from === 1) {
     console.log('Got an message from Pavel Durov!');
   }
+})
+```
+-------
+
+#### poll-error <a name="poll-error"></a>
+The poll-error event is emitted whenever there is an error occurred in LongPoll.
+
+```javascript
+bot.on('poll-error', error => {
+  console.error('error occurred on a working with the Long Poll server ' +
+    `(${util.inspect(error)})`)
 })
 ```
 -------

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "mocha": "^3.2.0",
     "tslint": "^4.4.2",
     "typescript": "^2.1.5",
-    "@types/node": "^7.0.4",
-    "@types/request": "0.0.39",
-    "@types/request-promise-native": "^1.0.2"
+    "@types/node": "^7.0.33",
+    "@types/request": "0.0.45",
+    "@types/request-promise-native": "^1.0.5"
   },
   "dependencies": {
     "request": "^2.79.0",

--- a/src/functions/poll.ts
+++ b/src/functions/poll.ts
@@ -8,7 +8,12 @@ export default function poll (bot) {
       return request(`https://${res.server}?act=a_check&key=${res.key}` +
         `&wait=25&mode=2&version=1&ts=${res.ts}`)
     })
-    .catch(() => poll(bot))
+    .catch(error => {
+      bot.emit('poll-error', error)
+
+      // перезапуск при ошибке
+      return poll(bot)
+    })
 
   function request (url) {
     return rq(url, { json: true })


### PR DESCRIPTION
Change log:

* transfer a handling of Long Poll server errors to a single place;
* emit an event (`poll-error`) on a Long Poll server error;
* _update dependencies with TypeScript type definitions_ (without it unit tests can't be built).

This allows you to additionally handle Long Poll server errors in a custom way, e.g.:

```javascript
bot.on('poll-error', error => {
  console.error('error occurred on a working with the Long Poll server ' +
    `(${util.inspect(error)})`)
})
```