### PR TITLE
Improve a working with a delay before a restart of the Long Poll client

### DIFF
--- a/src/functions/poll.ts
+++ b/src/functions/poll.ts
@@ -1,5 +1,7 @@
 import * as rq from 'request-promise-native'
 
+const DEFAULT_DELAY = 334 // 1/3 of a second
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 export default function poll (bot) {
@@ -31,7 +33,7 @@ export default function poll (bot) {
         }
 
         if (bot._stop) return null
-        return sleep(300).then(() => request(url))
+        return sleep(DEFAULT_DELAY).then(() => request(url))
       })
   }
 }

--- a/src/functions/poll.ts
+++ b/src/functions/poll.ts
@@ -4,20 +4,20 @@ const DEFAULT_DELAY = 334 // 1/3 of a second
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-export default function poll (bot) {
+export default function poll (bot, delay: number = DEFAULT_DELAY) {
   return bot.api('messages.getLongPollServer')
     .then(res => {
       return request(`https://${res.server}?act=a_check&key=${res.key}` +
-        `&wait=25&mode=2&version=1&ts=${res.ts}`)
+        `&wait=25&mode=2&version=1&ts=${res.ts}`, delay)
     })
     .catch(error => {
       bot.emit('poll-error', error)
 
       // перезапуск при ошибке
-      return poll(bot)
+      return poll(bot, delay)
     })
 
-  function request (url) {
+  function request (url, delay: number) {
     return rq(url, { json: true })
       .then(res => {
         if (!res || !res.ts || res.failed)
@@ -33,7 +33,7 @@ export default function poll (bot) {
         }
 
         if (bot._stop) return null
-        return sleep(DEFAULT_DELAY).then(() => request(url))
+        return sleep(delay).then(() => request(url, delay))
       })
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,11 +78,12 @@ export class Bot extends EventEmitter {
 
   /**
    * Start polling
+   * @param {number} poll_delay A delay before a restart of the Long Poll client
    * @returns The bot object
    */
-  start () {
+  start (poll_delay?: number) {
     this.on('update', this._update)
-    poll(this)
+    poll(this, poll_delay)
     return this
   }
 


### PR DESCRIPTION
Change log:

* increase a default delay before a restart of the Long Poll client;
* support a custom delay before a restart of the Long Poll client.
